### PR TITLE
chore: update `remark-cli` to version `^2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "gulp"        : "^3.9.1",
         "gulp-filter" : "^4.0.0",
         "gulp-replace": "^0.5.4",
-        "remark-cli"  : "^1.0.0",
+        "remark-cli"  : "^2.0.0",
         "remark-lint" : "^5.1.0",
         "semver"      : "^5.3.0"
     },


### PR DESCRIPTION
Update [remark-cli](https://www.npmjs.com/package/remark-cli) [:octocat:](https://github.com/wooorm/remark) version `^1.0.0` to `^2.0.0` (`devDependencies`).
## [2.0.0](https://github.com/wooorm/remark/compare/83e4af1c60a066512cc7030363e53e686e65ca24~...c8e6405bfe46da3c8f4e1aad0ae7b1518c27c446) - August 22, 2016
- [`c8e6405`](https://github.com/wooorm/remark/commit/c8e6405bfe46da3c8f4e1aad0ae7b1518c27c446) Remove Node@0.12, Node@4 from Travis targets
- [`24c6890`](https://github.com/wooorm/remark/commit/24c6890342af6934f9a47ddff7c304041ad9edb3) Add support for presets, better vfile’s, more
- [`f452b82`](https://github.com/wooorm/remark/commit/f452b8252529f89eaddc811e5d608d8186557646) Remove internal remark use for updates to come
- [`904aaee`](https://github.com/wooorm/remark/commit/904aaee800f5e3fd624071c5555ab066eb792d1f) Refactor code-style to use `xo`
- [`be0eac7`](https://github.com/wooorm/remark/commit/be0eac7cd59390f2a164f84f0b585541fd3a108c) Update dev-dependencies
- [`dc8f74b`](https://github.com/wooorm/remark/commit/dc8f74bc58d25e422479fefd77dc525e0062474f) 5.1.0
- [`7ab5623`](https://github.com/wooorm/remark/commit/7ab5623dab47b7acffe33c4344f4d6863c50f2b2) Add more projects to list of products
- [`1cd809d`](https://github.com/wooorm/remark/commit/1cd809d27dd3958461c6b56c59113b22a65e691b) Add `awesome-lint` to list of products
- [`f919648`](https://github.com/wooorm/remark/commit/f919648795c97853238e048e494aa3ad65fa25c1) Fix white-space only lines to be seen as blank lines
- [`fd77939`](https://github.com/wooorm/remark/commit/fd77939afac608aa85004e442c6168c17e91aaf6) Fix link escaping
- [`7460933`](https://github.com/wooorm/remark/commit/7460933793e379f14e2f15c7b224b73f16febd88) Fix link parsing algorithm’s handling of brackets
- [`58a7036`](https://github.com/wooorm/remark/commit/58a70360183c5fee5a860c4ee8a698d28d8b3561) Fix escapiping of loose links in GFM
- [`484f82b`](https://github.com/wooorm/remark/commit/484f82baedce019aa89c1e2dd6d6e0a9aacaf7e5) Add `remark-rehype` to list of plug-ins
- [`d0681f2`](https://github.com/wooorm/remark/commit/d0681f27857fd340ca6da5310f5e3a86eb19604c) Add `remark-yaml-annotations` to list of plug-ins
- [`1617a6c`](https://github.com/wooorm/remark/commit/1617a6c04b38c88a4590e74d72706a0ed00d537a) Add support for spaced gfm links
- [`52e4e80`](https://github.com/wooorm/remark/commit/52e4e80651ddf965b3e895401745264aea0034ad) Fix incorrect setext detection algorithm
- [`b7709c7`](https://github.com/wooorm/remark/commit/b7709c7891e5af85c39c1dbb414d3498825fed32) Fix coverage for 97b2e12
- [`97b2e12`](https://github.com/wooorm/remark/commit/97b2e12d5367f0c969274feba2313748eb5792b7) Fix when list-item markers interrupt paragraphs
- [`e4115d1`](https://github.com/wooorm/remark/commit/e4115d1cd9dec667de7e952b89f4fa71f6240793) Update lerna
- [`b23ed72`](https://github.com/wooorm/remark/commit/b23ed7227806069bbe9171d3eabe90c48cc0e67e) Re-add internal remark plugins
- [`68690ce`](https://github.com/wooorm/remark/commit/68690ceff4cfe797c1c4ea427e8c8b48f188169f) Remove list of utilities
- [`3489be7`](https://github.com/wooorm/remark/commit/3489be7368cdebf1c3a9fd907780d481c3f8f22f) Fix to bust `remark` `readme.md` on npm
- [`ef6cb06`](https://github.com/wooorm/remark/commit/ef6cb06bb20ecca558f8878f2fec3a5831e11dd2) 5.0.0
- [`83e4af1`](https://github.com/wooorm/remark/commit/83e4af1c60a066512cc7030363e53e686e65ca24) Fix `lerna.json`
